### PR TITLE
chore(nox): Use nox to test against multiple Python versions

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -1,0 +1,20 @@
+"""Nox sessions."""
+import nox
+from nox.sessions import Session
+
+nox.options.sessions = [
+    "tests",
+]
+
+
+@nox.session(python=["3.9", "3.10"])
+def tests(session: Session) -> None:
+    """Run the test suite."""
+    args = session.posargs or ["--cov"]
+
+    # install the package itself into a new virtual environment with dev and tests
+    # optional dependencies
+    session.install(".[dev,tests]")
+
+    # run pytest against the installed package
+    session.run("pytest", *args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,28 +17,33 @@ classifiers = [
     "Topic :: Office/Business :: Financial",
     "Topic :: Office/Business :: Financial :: Accounting",
     "Topic :: Office/Business :: Financial :: Investment",
-    "Typing :: Typed",
 ]
 dependencies = [
-    "numpy>=1.23.0",
-    "pandas>=1.4.3",
+    "numpy >= 1.23.2",
+    "pandas >= 1.4.4",
 ]
+
 [project.optional-dependencies]
 dev = [
-    "black>=22.6.0",
-    "pytest>=7.1.2",
-    "pytest-cov>=3.0.0",
-    "tox>=3.25.1"
+    "black >= 22.8.0",
+    "isort >= 5.10.0",
+    "nox >= 2022.8.7"
 ]
-doc = [
-    "jupyter>=1.0.0",
-    "nbsphinx>=0.8.9",
-    "numpydoc>=1.4.0",
-    "openpyxl>=3.0.10",
-    "pandoc>=2.2",
-    "sphinx>=5.0.2",
-    "sphinx-rtd-theme>=1.0.0",
+docs = [
+    "jupyter >= 1.0.0",
+    "nbsphinx >= 0.8.9",
+    "numpydoc >= 1.4.0",
+    "openpyxl >= 3.0.10",
+    "pandoc >= 2.2",
+    "sphinx >= 5.0.2",
+    "sphinx-rtd-theme >= 1.0.0",
 ]
+tests = [
+    "coverage[toml] >= 6.4.4",
+    "pytest >= 7.1.3",
+    "pytest-cov >= 3.0.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/hsbc/pyratings"
 Repository = "https://github.com/hsbc/pyratings"
@@ -46,27 +51,35 @@ BugTracker = "https://github.com/hsbc/pyratings/issues"
 Documentation = "https://hsbc.github.io/pyratings/"
 Changelog = "https://github.com/hsbc/pyratings/blob/main/CHANGELOG.rst"
 
-[build-system]
-requires = ["flit_core >=3.2,<4"]
-build-backend = "flit_core.buildapi"
+[tool.black]
+target-version = ["py38", "py39", "py310"]
+include = '\.pyi?$'
+
+[tool.isort]
+profile = "black"
+src_paths = ["src", "tests"]
+
+[tool.coverage.paths]
+source = ["src", "*/site-packages"]
+tests = ["tests", "*/tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["pyindicators", "tests"]
+
+[tool.coverage.report]
+show_missing = true
+fail_under = 100
+exclude_lines = [
+    'if TYPE_CHECKING:',
+    'pragma: no cover'
+]
 
 [tool.pytest.ini_options]
-minversion = "6.0"
+minversion = "7.0"
 addopts = "--doctest-modules"
 doctest_optionflags = "NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER"
 
-[tool.tox]
-legacy_tox_ini = """
-[tox]
-isolated_build = True
-envlist = py39
-
-[pytest]
-minversion = '6.0'
-addopts = '--doctest-modules'
-doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL NUMBER
-
-[testenv]
-extras = dev
-commands = pytest {posargs}
-"""
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"


### PR DESCRIPTION
Transitioned from `tox` to `nox` in order to test against multiple
Python versions.