### PR TITLE
bug: Automatic column naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- BREAKING CHANGE: Automatic column naming  
+    - ``get_scores_from_ratings()``  
+      When input a ``pd.Series``, the name of the output series will now become
+      ``ratings.name`` prefixed with "rtg_score_".  
+      When input a ``pd.DataFrame``, the column names of the output frame will now 
+      become ``ratings.columns`` prefixed with "rtg_score_". 
+    - ``get_warf_from_ratings()``   
+      When input a pd.Series, the name of the output series will now become
+      ``ratings.name`` prefixed with "warf_".  
+      When input a pd.DataFrame, the column names of the output frame will now become 
+      ``ratings.columns`` prefixed with "warf_".
+ 
 ### Improved
 - Splitting the code base into multiple files in order to increase maintainability.
 - Documentation has been updated and will now be created via

--- a/docs/getting_started.ipynb
+++ b/docs/getting_started.ipynb
@@ -26,8 +26,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 1,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "           ISIN    weight BB Comp   SP   Moody Fitch\n0  ISIN00000001  0.518515     AAA   NR  Aaa *-   AAA\n1  ISIN00000002  0.950810     AAA  AA+     Aaa   AAA\n2  ISIN00000003  0.497176  AA+ *-  AA+     Aa2   NaN\n3  ISIN00000004  0.648453      NR  NaN      NR  AA-u\n4  ISIN00000005  0.674328      NR  NaN      NR  AA-u",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ISIN</th>\n      <th>weight</th>\n      <th>BB Comp</th>\n      <th>SP</th>\n      <th>Moody</th>\n      <th>Fitch</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>ISIN00000001</td>\n      <td>0.518515</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa *-</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>ISIN00000002</td>\n      <td>0.950810</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ISIN00000003</td>\n      <td>0.497176</td>\n      <td>AA+ *-</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>ISIN00000004</td>\n      <td>0.648453</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>ISIN00000005</td>\n      <td>0.674328</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "import pandas as pd\n",
     "\n",
@@ -65,8 +75,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 2,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "  BB Comp_clean SP_clean Moody_clean Fitch_clean\n0           AAA       NR         Aaa         AAA\n1           AAA      AA+         Aaa         AAA\n2           AA+      AA+         Aa2         NaN\n3            NR      NaN          NR         AA-\n4            NR      NaN          NR         AA-",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>BB Comp_clean</th>\n      <th>SP_clean</th>\n      <th>Moody_clean</th>\n      <th>Fitch_clean</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>AA+</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "ratings_clean_df = rtg.get_pure_ratings(\n",
     "    port_df.loc[:, [\"BB Comp\", \"SP\", \"Moody\", \"Fitch\"]]\n",
@@ -95,8 +115,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 3,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "           ISIN    weight BB Comp   SP   Moody Fitch BB Comp_clean SP_clean  \\\n0  ISIN00000001  0.518515     AAA   NR  Aaa *-   AAA           AAA       NR   \n1  ISIN00000002  0.950810     AAA  AA+     Aaa   AAA           AAA      AA+   \n2  ISIN00000003  0.497176  AA+ *-  AA+     Aa2   NaN           AA+      AA+   \n3  ISIN00000004  0.648453      NR  NaN      NR  AA-u            NR      NaN   \n4  ISIN00000005  0.674328      NR  NaN      NR  AA-u            NR      NaN   \n\n  Moody_clean Fitch_clean  \n0         Aaa         AAA  \n1         Aaa         AAA  \n2         Aa2         NaN  \n3          NR         AA-  \n4          NR         AA-  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ISIN</th>\n      <th>weight</th>\n      <th>BB Comp</th>\n      <th>SP</th>\n      <th>Moody</th>\n      <th>Fitch</th>\n      <th>BB Comp_clean</th>\n      <th>SP_clean</th>\n      <th>Moody_clean</th>\n      <th>Fitch_clean</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>ISIN00000001</td>\n      <td>0.518515</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa *-</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>ISIN00000002</td>\n      <td>0.950810</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ISIN00000003</td>\n      <td>0.497176</td>\n      <td>AA+ *-</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA+</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>ISIN00000004</td>\n      <td>0.648453</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>ISIN00000005</td>\n      <td>0.674328</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "port_df = pd.concat([port_df, ratings_clean_df], axis=1)\n",
     "port_df.head()"
@@ -137,8 +167,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 4,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "           ISIN    weight BB Comp   SP   Moody Fitch BB Comp_clean SP_clean  \\\n0  ISIN00000001  0.518515     AAA   NR  Aaa *-   AAA           AAA       NR   \n1  ISIN00000002  0.950810     AAA  AA+     Aaa   AAA           AAA      AA+   \n2  ISIN00000003  0.497176  AA+ *-  AA+     Aa2   NaN           AA+      AA+   \n3  ISIN00000004  0.648453      NR  NaN      NR  AA-u            NR      NaN   \n4  ISIN00000005  0.674328      NR  NaN      NR  AA-u            NR      NaN   \n\n  Moody_clean Fitch_clean worst_rtg  \n0         Aaa         AAA       AAA  \n1         Aaa         AAA       AA+  \n2         Aa2         NaN        AA  \n3          NR         AA-       AA-  \n4          NR         AA-       AA-  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ISIN</th>\n      <th>weight</th>\n      <th>BB Comp</th>\n      <th>SP</th>\n      <th>Moody</th>\n      <th>Fitch</th>\n      <th>BB Comp_clean</th>\n      <th>SP_clean</th>\n      <th>Moody_clean</th>\n      <th>Fitch_clean</th>\n      <th>worst_rtg</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>ISIN00000001</td>\n      <td>0.518515</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa *-</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>ISIN00000002</td>\n      <td>0.950810</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AA+</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ISIN00000003</td>\n      <td>0.497176</td>\n      <td>AA+ *-</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA+</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>ISIN00000004</td>\n      <td>0.648453</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>ISIN00000005</td>\n      <td>0.674328</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "port_df = pd.concat(\n",
     "    [\n",
@@ -208,8 +248,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 5,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "            ISIN    weight BB Comp   SP   Moody Fitch BB Comp_clean SP_clean  \\\n0   ISIN00000001  0.518515     AAA   NR  Aaa *-   AAA           AAA       NR   \n1   ISIN00000002  0.950810     AAA  AA+     Aaa   AAA           AAA      AA+   \n2   ISIN00000003  0.497176  AA+ *-  AA+     Aa2   NaN           AA+      AA+   \n3   ISIN00000004  0.648453      NR  NaN      NR  AA-u            NR      NaN   \n4   ISIN00000005  0.674328      NR  NaN      NR  AA-u            NR      NaN   \n..           ...       ...     ...  ...     ...   ...           ...      ...   \n82  ISIN00000083  2.321185      NR  NaN    Baa1   NaN            NR      NaN   \n83  ISIN00000084  1.389043      NR  NaN    Baa1   NaN            NR      NaN   \n84  ISIN00000085  2.296711    BBB+   NR    Baa1    A-          BBB+       NR   \n85  ISIN00000086  1.015105     AAA  AAA     Aaa   NaN           AAA      AAA   \n86  ISIN00000087  0.964399      AA  NaN     Aa2    AA            AA      NaN   \n\n   Moody_clean Fitch_clean worst_rtg  rtg_score_worst_rtg  \n0          Aaa         AAA       AAA                  1.0  \n1          Aaa         AAA       AA+                  2.0  \n2          Aa2         NaN        AA                  3.0  \n3           NR         AA-       AA-                  4.0  \n4           NR         AA-       AA-                  4.0  \n..         ...         ...       ...                  ...  \n82        Baa1         NaN      BBB+                  8.0  \n83        Baa1         NaN      BBB+                  8.0  \n84        Baa1          A-      BBB+                  8.0  \n85         Aaa         NaN       AAA                  1.0  \n86         Aa2          AA        AA                  3.0  \n\n[87 rows x 12 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ISIN</th>\n      <th>weight</th>\n      <th>BB Comp</th>\n      <th>SP</th>\n      <th>Moody</th>\n      <th>Fitch</th>\n      <th>BB Comp_clean</th>\n      <th>SP_clean</th>\n      <th>Moody_clean</th>\n      <th>Fitch_clean</th>\n      <th>worst_rtg</th>\n      <th>rtg_score_worst_rtg</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>ISIN00000001</td>\n      <td>0.518515</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa *-</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>1.0</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>ISIN00000002</td>\n      <td>0.950810</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>2.0</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ISIN00000003</td>\n      <td>0.497176</td>\n      <td>AA+ *-</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA+</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA</td>\n      <td>3.0</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>ISIN00000004</td>\n      <td>0.648453</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n      <td>4.0</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>ISIN00000005</td>\n      <td>0.674328</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n      <td>4.0</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>82</th>\n      <td>ISIN00000083</td>\n      <td>2.321185</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>BBB+</td>\n      <td>8.0</td>\n    </tr>\n    <tr>\n      <th>83</th>\n      <td>ISIN00000084</td>\n      <td>1.389043</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>BBB+</td>\n      <td>8.0</td>\n    </tr>\n    <tr>\n      <th>84</th>\n      <td>ISIN00000085</td>\n      <td>2.296711</td>\n      <td>BBB+</td>\n      <td>NR</td>\n      <td>Baa1</td>\n      <td>A-</td>\n      <td>BBB+</td>\n      <td>NR</td>\n      <td>Baa1</td>\n      <td>A-</td>\n      <td>BBB+</td>\n      <td>8.0</td>\n    </tr>\n    <tr>\n      <th>85</th>\n      <td>ISIN00000086</td>\n      <td>1.015105</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>Aaa</td>\n      <td>NaN</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>Aaa</td>\n      <td>NaN</td>\n      <td>AAA</td>\n      <td>1.0</td>\n    </tr>\n    <tr>\n      <th>86</th>\n      <td>ISIN00000087</td>\n      <td>0.964399</td>\n      <td>AA</td>\n      <td>NaN</td>\n      <td>Aa2</td>\n      <td>AA</td>\n      <td>AA</td>\n      <td>NaN</td>\n      <td>Aa2</td>\n      <td>AA</td>\n      <td>AA</td>\n      <td>3.0</td>\n    </tr>\n  </tbody>\n</table>\n<p>87 rows × 12 columns</p>\n</div>"
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "port_scores_df = pd.concat(\n",
     "    [\n",
@@ -249,11 +299,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 6,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average rating score: 4.387791453932187\n"
+     ]
+    }
+   ],
    "source": [
     "avg_rtg_score = rtg.get_weighted_average(\n",
-    "    data=port_scores_df[\"rtg_score_SP\"],\n",
+    "    data=port_scores_df[\"rtg_score_worst_rtg\"],\n",
     "    weights=port_scores_df[\"weight\"] / 100,\n",
     ")\n",
     "print(f\"Average rating score: {avg_rtg_score}\")"
@@ -267,8 +325,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 7,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Average portfolio rating: AA-\n"
+     ]
+    }
+   ],
    "source": [
     "avg_rtg = rtg.get_ratings_from_scores(\n",
     "    rating_scores=avg_rtg_score, rating_provider=\"S&P\")\n",
@@ -297,8 +363,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 8,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "           ISIN    weight BB Comp   SP   Moody Fitch BB Comp_clean SP_clean  \\\n0  ISIN00000001  0.518515     AAA   NR  Aaa *-   AAA           AAA       NR   \n1  ISIN00000002  0.950810     AAA  AA+     Aaa   AAA           AAA      AA+   \n2  ISIN00000003  0.497176  AA+ *-  AA+     Aa2   NaN           AA+      AA+   \n3  ISIN00000004  0.648453      NR  NaN      NR  AA-u            NR      NaN   \n4  ISIN00000005  0.674328      NR  NaN      NR  AA-u            NR      NaN   \n\n  Moody_clean Fitch_clean worst_rtg  \n0         Aaa         AAA       AAA  \n1         Aaa         AAA       AA+  \n2         Aa2         NaN        AA  \n3          NR         AA-       AA-  \n4          NR         AA-       AA-  ",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ISIN</th>\n      <th>weight</th>\n      <th>BB Comp</th>\n      <th>SP</th>\n      <th>Moody</th>\n      <th>Fitch</th>\n      <th>BB Comp_clean</th>\n      <th>SP_clean</th>\n      <th>Moody_clean</th>\n      <th>Fitch_clean</th>\n      <th>worst_rtg</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>ISIN00000001</td>\n      <td>0.518515</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa *-</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>ISIN00000002</td>\n      <td>0.950810</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AA+</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ISIN00000003</td>\n      <td>0.497176</td>\n      <td>AA+ *-</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA+</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>ISIN00000004</td>\n      <td>0.648453</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>ISIN00000005</td>\n      <td>0.674328</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "port_df.head()"
    ],
@@ -354,8 +430,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 9,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "            ISIN    weight BB Comp   SP   Moody Fitch BB Comp_clean SP_clean  \\\n0   ISIN00000001  0.518515     AAA   NR  Aaa *-   AAA           AAA       NR   \n1   ISIN00000002  0.950810     AAA  AA+     Aaa   AAA           AAA      AA+   \n2   ISIN00000003  0.497176  AA+ *-  AA+     Aa2   NaN           AA+      AA+   \n3   ISIN00000004  0.648453      NR  NaN      NR  AA-u            NR      NaN   \n4   ISIN00000005  0.674328      NR  NaN      NR  AA-u            NR      NaN   \n..           ...       ...     ...  ...     ...   ...           ...      ...   \n82  ISIN00000083  2.321185      NR  NaN    Baa1   NaN            NR      NaN   \n83  ISIN00000084  1.389043      NR  NaN    Baa1   NaN            NR      NaN   \n84  ISIN00000085  2.296711    BBB+   NR    Baa1    A-          BBB+       NR   \n85  ISIN00000086  1.015105     AAA  AAA     Aaa   NaN           AAA      AAA   \n86  ISIN00000087  0.964399      AA  NaN     Aa2    AA            AA      NaN   \n\n   Moody_clean Fitch_clean worst_rtg  warf_worst_rtg  \n0          Aaa         AAA       AAA             1.0  \n1          Aaa         AAA       AA+            10.0  \n2          Aa2         NaN        AA            20.0  \n3           NR         AA-       AA-            40.0  \n4           NR         AA-       AA-            40.0  \n..         ...         ...       ...             ...  \n82        Baa1         NaN      BBB+           260.0  \n83        Baa1         NaN      BBB+           260.0  \n84        Baa1          A-      BBB+           260.0  \n85         Aaa         NaN       AAA             1.0  \n86         Aa2          AA        AA            20.0  \n\n[87 rows x 12 columns]",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>ISIN</th>\n      <th>weight</th>\n      <th>BB Comp</th>\n      <th>SP</th>\n      <th>Moody</th>\n      <th>Fitch</th>\n      <th>BB Comp_clean</th>\n      <th>SP_clean</th>\n      <th>Moody_clean</th>\n      <th>Fitch_clean</th>\n      <th>worst_rtg</th>\n      <th>warf_worst_rtg</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>ISIN00000001</td>\n      <td>0.518515</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa *-</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>NR</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>1.0</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>ISIN00000002</td>\n      <td>0.950810</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>Aaa</td>\n      <td>AAA</td>\n      <td>AA+</td>\n      <td>10.0</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>ISIN00000003</td>\n      <td>0.497176</td>\n      <td>AA+ *-</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA+</td>\n      <td>AA+</td>\n      <td>Aa2</td>\n      <td>NaN</td>\n      <td>AA</td>\n      <td>20.0</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>ISIN00000004</td>\n      <td>0.648453</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n      <td>40.0</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>ISIN00000005</td>\n      <td>0.674328</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-u</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>AA-</td>\n      <td>AA-</td>\n      <td>40.0</td>\n    </tr>\n    <tr>\n      <th>...</th>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n      <td>...</td>\n    </tr>\n    <tr>\n      <th>82</th>\n      <td>ISIN00000083</td>\n      <td>2.321185</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>BBB+</td>\n      <td>260.0</td>\n    </tr>\n    <tr>\n      <th>83</th>\n      <td>ISIN00000084</td>\n      <td>1.389043</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>NR</td>\n      <td>NaN</td>\n      <td>Baa1</td>\n      <td>NaN</td>\n      <td>BBB+</td>\n      <td>260.0</td>\n    </tr>\n    <tr>\n      <th>84</th>\n      <td>ISIN00000085</td>\n      <td>2.296711</td>\n      <td>BBB+</td>\n      <td>NR</td>\n      <td>Baa1</td>\n      <td>A-</td>\n      <td>BBB+</td>\n      <td>NR</td>\n      <td>Baa1</td>\n      <td>A-</td>\n      <td>BBB+</td>\n      <td>260.0</td>\n    </tr>\n    <tr>\n      <th>85</th>\n      <td>ISIN00000086</td>\n      <td>1.015105</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>Aaa</td>\n      <td>NaN</td>\n      <td>AAA</td>\n      <td>AAA</td>\n      <td>Aaa</td>\n      <td>NaN</td>\n      <td>AAA</td>\n      <td>1.0</td>\n    </tr>\n    <tr>\n      <th>86</th>\n      <td>ISIN00000087</td>\n      <td>0.964399</td>\n      <td>AA</td>\n      <td>NaN</td>\n      <td>Aa2</td>\n      <td>AA</td>\n      <td>AA</td>\n      <td>NaN</td>\n      <td>Aa2</td>\n      <td>AA</td>\n      <td>AA</td>\n      <td>20.0</td>\n    </tr>\n  </tbody>\n</table>\n<p>87 rows × 12 columns</p>\n</div>"
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "port_warf_df = pd.concat(\n",
     "    [\n",
@@ -396,11 +482,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 10,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARF: 165.57723587360007\n"
+     ]
+    }
+   ],
    "source": [
     "avg_warf = rtg.get_weighted_average(\n",
-    "    data=port_warf_df[\"warf\"], weights=port_warf_df[\"weight\"] / 100\n",
+    "    data=port_warf_df[\"warf_worst_rtg\"], weights=port_warf_df[\"weight\"] / 100\n",
     ")\n",
     "\n",
     "print(f\"WARF: {avg_warf}\")"
@@ -426,8 +520,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
+   "execution_count": 11,
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Portfolio equivalent WARF rating: A3\n"
+     ]
+    }
+   ],
    "source": [
     "avg_warf_equivalent_rating = rtg.get_ratings_from_warf(\n",
     "    warf=avg_warf, rating_provider=\"Moody\")\n",

--- a/src/pyratings/get_scores.py
+++ b/src/pyratings/get_scores.py
@@ -103,6 +103,12 @@ def get_scores_from_ratings(
     Union[int, pd.Series, pd.DataFrame]
         Numerical rating score(s)
 
+        If returns a ``pd.Series``, the series name will be `rtg_score`
+        suffixed by `ratings.name`.
+
+        If return a ``pd.DataFrame``, the column names will be `rtg_score` suffixed
+        by the respective `ratings.columns`.
+
     Raises
     ------
     ValueError
@@ -118,7 +124,9 @@ def get_scores_from_ratings(
     Converting a ``pd.Series`` of ratings:
 
     >>> import pandas as pd
-    >>> ratings_series = pd.Series(data=["Baa1", "C", "NR", "WD", "D", "B1", "SD"])
+    >>> ratings_series = pd.Series(
+    ...     data=["Baa1", "C", "NR", "WD", "D", "B1", "SD"], name='Moody'
+    ... )
     >>> get_scores_from_ratings(
     ...     ratings=ratings_series, rating_provider="Moody's", tenor="long-term"
     ... )
@@ -149,7 +157,8 @@ def get_scores_from_ratings(
     Converting a ``pd.DataFrame`` with ratings:
 
     >>> ratings_df = pd.DataFrame(
-    ...     data=[["BB+", "B3", "BBB-"], ["AA-", "Aa1", "AAA"], ["D", "NR", "D"]]
+    ...     data=[["BB+", "B3", "BBB-"], ["AA-", "Aa1", "AAA"], ["D", "NR", "D"]],
+    ...     columns=["SP", "Moody", "DBRS"],
     ... )
     >>> get_scores_from_ratings(
     ...     ratings=ratings_df,
@@ -172,10 +181,10 @@ def get_scores_from_ratings(
     ...     }
     ... )
     >>> get_scores_from_ratings(ratings=ratings_df)
-       rtg_score_Fitch  rtg_score_Bloomberg  rtg_score_DBRS
-    0               11                 16.0             NaN
-    1                4                  2.0             1.0
-    2               22                  NaN            22.0
+       rtg_score_rtg_fitch  rtg_score_rtg_Bloomberg  rtg_score_DBRS Ratings
+    0                   11                     16.0                     NaN
+    1                    4                      2.0                     1.0
+    2                   22                      NaN                    22.0
 
     """
     if isinstance(ratings, str):
@@ -200,9 +209,7 @@ def get_scores_from_ratings(
             )
 
         rtg_dict = _get_translation_dict("rtg_to_scores", rating_provider, tenor=tenor)
-        return pd.Series(
-            data=ratings.map(rtg_dict), name=f"rtg_score_{rating_provider}"
-        )
+        return pd.Series(data=ratings.map(rtg_dict), name=f"rtg_score_{ratings.name}")
 
     elif isinstance(ratings, pd.DataFrame):
         if rating_provider is None:

--- a/tests/test_get_scores.py
+++ b/tests/test_get_scores.py
@@ -132,7 +132,7 @@ def test_get_scores_from_ratings_series_longterm(
     rating_provider: str, ratings_series: pd.Series, scores_series: pd.Series
 ) -> None:
     """It returns a series with rating scores."""
-    scores_series.name = f"rtg_score_{rating_provider}"
+    scores_series.name = f"rtg_score_{ratings_series.name}"
     act = rtg.get_scores_from_ratings(
         ratings=ratings_series, rating_provider=rating_provider
     )
@@ -147,7 +147,7 @@ def test_get_scores_from_ratings_series_shortterm(
     rating_provider: str, ratings_series: pd.Series, scores_series: pd.Series
 ) -> None:
     """It returns a series with rating scores."""
-    scores_series.name = f"rtg_score_{rating_provider}"
+    scores_series.name = f"rtg_score_{ratings_series.name}"
     act = rtg.get_scores_from_ratings(
         ratings=ratings_series, rating_provider=rating_provider, tenor="short-term"
     )
@@ -171,7 +171,7 @@ def test_get_scores_from_ratings_series_invalid_rating_provider(tenor: str) -> N
 def test_get_scores_from_invalid_ratings_series(tenor: str) -> None:
     """It returns a series with NaNs."""
     ratings_series = pd.Series(data=[np.nan, "foo", -10], name="rating")
-    scores_series = pd.Series(data=[np.nan, np.nan, np.nan], name="rtg_score_Fitch")
+    scores_series = pd.Series(data=[np.nan, np.nan, np.nan], name="rtg_score_rating")
 
     act = rtg.get_scores_from_ratings(
         ratings=ratings_series, rating_provider="Fitch", tenor=tenor

--- a/tests/test_get_warf.py
+++ b/tests/test_get_warf.py
@@ -87,7 +87,7 @@ def test_get_warf_from_rating_scores_series() -> None:
     """It returns a series with WARFs."""
     scores_series = conftest.scores_df_wide.iloc[:, 0]
     warf_series = conftest.warf_df_wide.iloc[:, 0]
-    warf_series.name = "warf"
+    warf_series.name = "warf_Fitch"
 
     act = rtg.get_warf_from_scores(rating_scores=scores_series)
     assert_series_equal(act, warf_series)
@@ -96,7 +96,7 @@ def test_get_warf_from_rating_scores_series() -> None:
 def test_get_warf_from_invalid_rating_scores_series() -> None:
     """It returns a series with NaNs."""
     scores_series = pd.Series(data=[np.nan, "foo", -10], name="rtg_score")
-    warf_series = pd.Series(data=[np.nan, np.nan, np.nan], name="warf")
+    warf_series = pd.Series(data=[np.nan, np.nan, np.nan], name="warf_rtg_score")
 
     act = rtg.get_warf_from_scores(rating_scores=scores_series)
     assert_series_equal(act, warf_series)
@@ -113,6 +113,7 @@ def test_get_warf_from_ratings_series(
     act = rtg.get_warf_from_ratings(
         ratings=ratings_series, rating_provider=rating_provider
     )
+    warf_series.name = "warf_rating"
     assert_series_equal(act, warf_series)
 
 
@@ -129,7 +130,7 @@ def test_get_warf_from_ratings_series_invalid_rating_provider() -> None:
 def test_get_warf_from_invalid_ratings_series() -> None:
     """It returns a series with NaNs."""
     ratings_series = pd.Series(data=[np.nan, "foo", 10], name="Fitch Ratings")
-    warf_series = pd.Series(data=[np.nan, np.nan, np.nan], name="warf")
+    warf_series = pd.Series(data=[np.nan, np.nan, np.nan], name="warf_Fitch Ratings")
 
     act = rtg.get_warf_from_ratings(ratings=ratings_series)
     assert_series_equal(act, warf_series)


### PR DESCRIPTION
Perform review and test code base:

1. Clone/Pull the branch: git checkout -t origin/fix_col_naming_9
2. Activate your virtual env
3. pip install --upgrade -e .[dev,docs,tests]
4. ``pytest``
---

* ``get_scores_from_ratings()``
  When input a ``pd.Series``, the name of the output series will now become ``ratings.name`` prefixed with "rtg_score_".  
  When input a ``pd.DataFrame``, the column names of the output frame will now become ``ratings.columns`` prefixed with "rtg_score_".

  The last column name is an example from the "Getting started..." section of the documentation, where the `worst_rtg` column has been used as an input parameter.

![image](https://user-images.githubusercontent.com/104636025/199733786-2d0ba1c7-1aed-42da-b75f-ae60c5811183.png)

* ``get_warf_from_ratings()``
  When input a ``pd.Series``, the name of the output series will now become ``ratings.name`` prefixed with "warf_".  
  When input a ``pd.DataFrame``, the column names of the output frame will now become ``ratings.columns`` prefixed with "warf_".

  The last column name is an example from the "Getting started..." section of the documentation, where the `worst_rtg` column has been used as an input parameter.
 
![image](https://user-images.githubusercontent.com/104636025/199734025-d6d2e608-57d0-40a2-88ea-6081f4736fb7.png)

Closes #9