### PR TITLE
refactor: Handle valid rating agencies more flexible

### DIFF
--- a/src/pyratings/__init__.py
+++ b/src/pyratings/__init__.py
@@ -22,16 +22,11 @@ from pyratings.consolidate import (
 from pyratings.get_ratings import get_ratings_from_scores, get_ratings_from_warf
 from pyratings.get_scores import get_scores_from_ratings, get_scores_from_warf
 from pyratings.get_warf import get_warf_from_ratings, get_warf_from_scores
-from pyratings.utils import (
-    _assert_rating_provider,
-    _extract_rating_provider,
-    _get_translation_dict,
-)
+from pyratings.utils import _extract_rating_provider, _get_translation_dict
 from pyratings.warf import get_warf_buffer
 
 # define public functions
 __all__ = [
-    "_assert_rating_provider",
     "_extract_rating_provider",
     "_get_translation_dict",
     "get_best_ratings",

--- a/src/pyratings/consolidate.py
+++ b/src/pyratings/consolidate.py
@@ -20,7 +20,7 @@ import pandas as pd
 
 from pyratings.get_ratings import get_ratings_from_scores
 from pyratings.get_scores import get_scores_from_ratings
-from pyratings.utils import _extract_rating_provider
+from pyratings.utils import _extract_rating_provider, valid_rtg_agncy
 
 
 def get_best_ratings(
@@ -75,7 +75,10 @@ def get_best_ratings(
     Name: best_rtg, dtype: object
 
     """
-    rating_provider_output = _extract_rating_provider(rating_provider_output, tenor)
+    rating_provider_output = _extract_rating_provider(
+        rating_provider=rating_provider_output,
+        valid_rtg_provider=valid_rtg_agncy[tenor],
+    )
 
     # translate ratings -> scores
     rating_scores_df = get_scores_from_ratings(
@@ -147,7 +150,10 @@ def get_second_best_ratings(
     Name: second_best_rtg, dtype: object
 
     """
-    rating_provider_output = _extract_rating_provider(rating_provider_output, tenor)
+    rating_provider_output = _extract_rating_provider(
+        rating_provider=rating_provider_output,
+        valid_rtg_provider=valid_rtg_agncy[tenor],
+    )
 
     # translate ratings -> scores
     rating_scores_df = get_scores_from_ratings(
@@ -223,7 +229,10 @@ def get_worst_ratings(
     Name: worst_rtg, dtype: object
 
     """
-    rating_provider_output = _extract_rating_provider(rating_provider_output, tenor)
+    rating_provider_output = _extract_rating_provider(
+        rating_provider=rating_provider_output,
+        valid_rtg_provider=valid_rtg_agncy[tenor],
+    )
 
     # translate ratings -> scores
     rating_scores_df = get_scores_from_ratings(

--- a/src/pyratings/get_ratings.py
+++ b/src/pyratings/get_ratings.py
@@ -72,6 +72,7 @@ from pyratings.utils import (
     VALUE_ERROR_PROVIDER_MANDATORY,
     _extract_rating_provider,
     _get_translation_dict,
+    valid_rtg_agncy,
 )
 
 
@@ -186,7 +187,8 @@ def get_ratings_from_scores(
             raise ValueError(VALUE_ERROR_PROVIDER_MANDATORY)
 
         rating_provider = _extract_rating_provider(
-            rating_provider=rating_provider, tenor=tenor
+            rating_provider=rating_provider,
+            valid_rtg_provider=valid_rtg_agncy[tenor],
         )
 
         rtg_dict = _get_translation_dict(
@@ -200,11 +202,13 @@ def get_ratings_from_scores(
     elif isinstance(rating_scores, pd.Series):
         if rating_provider is None:
             rating_provider = _extract_rating_provider(
-                rating_provider=rating_scores.name, tenor=tenor
+                rating_provider=rating_scores.name,
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
         else:
             rating_provider = _extract_rating_provider(
-                rating_provider=rating_provider, tenor=tenor
+                rating_provider=rating_provider,
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
 
         rtg_dict = _get_translation_dict("scores_to_rtg", rating_provider, tenor=tenor)
@@ -221,11 +225,13 @@ def get_ratings_from_scores(
     elif isinstance(rating_scores, pd.DataFrame):
         if rating_provider is None:
             rating_provider = _extract_rating_provider(
-                rating_provider=rating_scores.columns.to_list(), tenor=tenor
+                rating_provider=rating_scores.columns.to_list(),
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
         else:
             rating_provider = _extract_rating_provider(
-                rating_provider=rating_provider, tenor=tenor
+                rating_provider=rating_provider,
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
 
         # Recursive call of 'get_ratings_from_score' for every column in dataframe
@@ -307,7 +313,8 @@ def get_ratings_from_warf(
             raise ValueError(VALUE_ERROR_PROVIDER_MANDATORY)
 
         rating_provider = _extract_rating_provider(
-            rating_provider=rating_provider, tenor="long-term"
+            rating_provider=rating_provider,
+            valid_rtg_provider=valid_rtg_agncy["long-term"],
         )
 
         rating_scores = get_scores_from_warf(warf=warf)

--- a/src/pyratings/get_scores.py
+++ b/src/pyratings/get_scores.py
@@ -75,6 +75,7 @@ from pyratings.utils import (
     VALUE_ERROR_PROVIDER_MANDATORY,
     _extract_rating_provider,
     _get_translation_dict,
+    valid_rtg_agncy,
 )
 
 
@@ -192,7 +193,8 @@ def get_scores_from_ratings(
             raise ValueError(VALUE_ERROR_PROVIDER_MANDATORY)
 
         rating_provider = _extract_rating_provider(
-            rating_provider=rating_provider, tenor=tenor
+            rating_provider=rating_provider,
+            valid_rtg_provider=valid_rtg_agncy[tenor],
         )
 
         rtg_dict = _get_translation_dict("rtg_to_scores", rating_provider, tenor=tenor)
@@ -201,11 +203,13 @@ def get_scores_from_ratings(
     elif isinstance(ratings, pd.Series):
         if rating_provider is None:
             rating_provider = _extract_rating_provider(
-                rating_provider=ratings.name, tenor=tenor
+                rating_provider=ratings.name,
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
         else:
             rating_provider = _extract_rating_provider(
-                rating_provider=rating_provider, tenor=tenor
+                rating_provider=rating_provider,
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
 
         rtg_dict = _get_translation_dict("rtg_to_scores", rating_provider, tenor=tenor)
@@ -214,11 +218,13 @@ def get_scores_from_ratings(
     elif isinstance(ratings, pd.DataFrame):
         if rating_provider is None:
             rating_provider = _extract_rating_provider(
-                rating_provider=ratings.columns.to_list(), tenor=tenor
+                rating_provider=ratings.columns.to_list(),
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
         else:
             rating_provider = _extract_rating_provider(
-                rating_provider=rating_provider, tenor=tenor
+                rating_provider=rating_provider,
+                valid_rtg_provider=valid_rtg_agncy[tenor],
             )
 
         # Recursive call of `get_scores_from_ratings`

--- a/src/pyratings/get_warf.py
+++ b/src/pyratings/get_warf.py
@@ -50,7 +50,11 @@ import numpy as np
 import pandas as pd
 
 from pyratings.get_scores import get_scores_from_ratings
-from pyratings.utils import _extract_rating_provider, _get_translation_dict
+from pyratings.utils import (
+    _extract_rating_provider,
+    _get_translation_dict,
+    valid_rtg_agncy,
+)
 
 
 def get_warf_from_scores(
@@ -222,7 +226,8 @@ def get_warf_from_ratings(
     """
     if rating_provider is not None:
         rating_provider = _extract_rating_provider(
-            rating_provider=rating_provider, tenor="long-term"
+            rating_provider=rating_provider,
+            valid_rtg_provider=valid_rtg_agncy["long-term"],
         )
 
     warf_dict = _get_translation_dict("scores_to_warf")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -269,11 +269,15 @@ exp_invalid_df = pd.DataFrame(
 )
 
 # --- error message constant with respect to invalid rating provider -------------------
-ERR_MSG = (
+ERR_MSG_LT = (
     "'foo' is not a valid rating provider. 'rating_provider' must "
-    "be in ['Moody', 'SP', 'Fitch', 'Bloomberg', 'DBRS', 'ICE']."
+    "be in ['fitch', 'moody', 'sp', 's&p', 'dbrs', 'bloomberg', 'ice']."
 )
 
+ERR_MSG_ST = (
+    "'foo' is not a valid rating provider. 'rating_provider' must "
+    "be in ['fitch', 'moody', 'sp', 's&p', 'dbrs']."
+)
 # --- params ---------------------------------------------------------------------------
 params_provider_scores_ratings_lt = [
     (

--- a/tests/test_consolidate.py
+++ b/tests/test_consolidate.py
@@ -244,7 +244,7 @@ def test_get_worst_rating_longterm_invalid_provider() -> None:
             tenor="long-term",
         )
 
-    assert str(err.value) == conftest.ERR_MSG
+    assert str(err.value) == conftest.ERR_MSG_LT
 
 
 def test_get_worst_rating_shortterm_invalid_provider() -> None:
@@ -262,5 +262,6 @@ def test_get_worst_rating_shortterm_invalid_provider() -> None:
         )
 
     assert str(err.value) == (
-        "rating_provider must be in ['Moody', 'SP', 'Fitch', 'DBRS']."
+        "'ICE' is not a valid rating provider. 'rating_provider' must be in "
+        "['fitch', 'moody', 'sp', 's&p', 'dbrs']."
     )

--- a/tests/test_get_ratings.py
+++ b/tests/test_get_ratings.py
@@ -111,7 +111,10 @@ def test_get_ratings_from_single_score_invalid_rating_provider(tenor: str) -> No
         rtg.get_ratings_from_scores(
             rating_scores=10, rating_provider="foo", tenor=tenor
         )
-    assert str(err.value) == conftest.ERR_MSG
+    if tenor == "long-term":
+        assert str(err.value) == conftest.ERR_MSG_LT
+    else:
+        assert str(err.value) == conftest.ERR_MSG_ST
 
 
 @pytest.mark.parametrize("tenor", ["long-term", "short-term"])
@@ -221,7 +224,10 @@ def test_get_ratings_from_scores_series_invalid_rating_provider(tenor: str) -> N
             tenor=tenor,
         )
 
-    assert str(err.value) == conftest.ERR_MSG
+    if tenor == "long-term":
+        assert str(err.value) == conftest.ERR_MSG_LT
+    else:
+        assert str(err.value) == conftest.ERR_MSG_ST
 
 
 @pytest.mark.parametrize("tenor", ["long-term", "short-term"])
@@ -233,7 +239,10 @@ def test_get_ratings_from_scores_series_with_no_rating_provider(tenor: str) -> N
             tenor=tenor,
         )
 
-    assert str(err.value) == conftest.ERR_MSG
+    if tenor == "long-term":
+        assert str(err.value) == conftest.ERR_MSG_LT
+    else:
+        assert str(err.value) == conftest.ERR_MSG_ST
 
 
 @pytest.mark.parametrize("tenor", ["long-term", "short-term"])
@@ -392,7 +401,10 @@ def test_get_ratings_from_scores_df_invalid_rating_provider(tenor: str) -> None:
         rtg.get_ratings_from_scores(
             rating_scores=conftest.scores_df_wide, rating_provider="foo", tenor=tenor
         )
-    assert str(err.value) == conftest.ERR_MSG
+    if tenor == "long-term":
+        assert str(err.value) == conftest.ERR_MSG_LT
+    else:
+        assert str(err.value) == conftest.ERR_MSG_ST
 
 
 @pytest.mark.parametrize("tenor", ["long-term", "short-term"])

--- a/tests/test_get_scores.py
+++ b/tests/test_get_scores.py
@@ -78,7 +78,10 @@ def test_get_scores_from_single_rating_invalid_rating_provider(tenor: str) -> No
     with pytest.raises(AssertionError) as err:
         rtg.get_scores_from_ratings(ratings="AA", rating_provider="foo", tenor=tenor)
 
-    assert str(err.value) == conftest.ERR_MSG
+    if tenor == "long-term":
+        assert str(err.value) == conftest.ERR_MSG_LT
+    else:
+        assert str(err.value) == conftest.ERR_MSG_ST
 
 
 @pytest.mark.parametrize("tenor", ["long-term", "short-term"])
@@ -164,7 +167,10 @@ def test_get_scores_from_ratings_series_invalid_rating_provider(tenor: str) -> N
             tenor=tenor,
         )
 
-    assert str(err.value) == conftest.ERR_MSG
+    if tenor == "long-term":
+        assert str(err.value) == conftest.ERR_MSG_LT
+    else:
+        assert str(err.value) == conftest.ERR_MSG_ST
 
 
 @pytest.mark.parametrize("tenor", ["long-term", "short-term"])
@@ -297,7 +303,10 @@ def test_get_scores_from_ratings_df_invalid_rating_provider(tenor: str) -> None:
             ratings=conftest.rtg_df_wide, rating_provider="foo", tenor=tenor
         )
 
-    assert str(err.value) == conftest.ERR_MSG
+    if tenor == "long-term":
+        assert str(err.value) == conftest.ERR_MSG_LT
+    else:
+        assert str(err.value) == conftest.ERR_MSG_ST
 
 
 @pytest.mark.parametrize("tenor", ["long-term", "short-term"])

--- a/tests/test_get_warf.py
+++ b/tests/test_get_warf.py
@@ -73,7 +73,7 @@ def test_get_warf_from_single_rating_invalid_rating_provider() -> None:
     with pytest.raises(AssertionError) as err:
         rtg.get_warf_from_ratings(ratings="AA", rating_provider="foo")
 
-    assert str(err.value) == conftest.ERR_MSG
+    assert str(err.value) == conftest.ERR_MSG_LT
 
 
 def test_get_warf_with_invalid_single_rating() -> None:
@@ -124,7 +124,7 @@ def test_get_warf_from_ratings_series_invalid_rating_provider() -> None:
             ratings=pd.Series(data=["AAA", "AA", "D"], name="foo")
         )
 
-    assert str(err.value) == conftest.ERR_MSG
+    assert str(err.value) == conftest.ERR_MSG_LT
 
 
 def test_get_warf_from_invalid_ratings_series() -> None:
@@ -195,7 +195,7 @@ def test_get_warf_from_ratings_dataframe_invalid_rating_provider() -> None:
     with pytest.raises(AssertionError) as err:
         rtg.get_warf_from_ratings(ratings=conftest.rtg_df_wide, rating_provider="foo")
 
-    assert str(err.value) == conftest.ERR_MSG
+    assert str(err.value) == conftest.ERR_MSG_LT
 
 
 def test_get_warf_from_invalid_ratings_dataframe() -> None:


### PR DESCRIPTION
1. git fetch -a
2. git checkout -t origin/refactor_valid_providers_20
3. Activate your virtual env
4. pip install --upgrade -e .[dev,docs,tests]
5. ``pytest`` or ``nox`` to perform more rigorous testing (recommended).
---

The ``_extract_rating_provider`` function now accepts a new input argument called ``valid_rtg_provider``, which is a list of strings. This allows for more flexibility going forward.

The function ``_assert_rating_provider`` has been dropped.

Closes #20