### PR TITLE
refactor: Adhere to new flake8 restrictions

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -36,6 +36,12 @@ ignore =
     ANN101, ANN102
     # Dynamically typed expressions (typing.Any) are disallowed (ANN401)
     ANN401,
+    # B905**: ``zip()`` without explicit `strict=` parameter set. ``strict=True``
+    # causes the resulting iterator to raise a ``ValueError`` if the arguments are
+    # exhausted at differing lengths. The ``strict=`` argument was added in Python 3.10,
+    # so don't enable this flag for code that should work on <3.10. For more
+    # information: https://peps.python.org/pep-0618/
+    B905,
     # Whitespace before ':' (E203)
     E203,
     # flake8-bandit

--- a/src/pyratings/utils.py
+++ b/src/pyratings/utils.py
@@ -101,7 +101,7 @@ def _extract_rating_provider(
     for i, provider in enumerate(rating_provider):
         if not any(x in provider.lower() for x in valid_rtg_provider_lowercase):
             raise AssertionError(
-                f"'{provider}' is not a valid rating provider. 'rating_provider' must "
+                f"{provider!r} is not a valid rating provider. 'rating_provider' must "
                 f"be in {valid_rtg_provider}."
             )
         for valid_provider in valid_rtg_provider:


### PR DESCRIPTION
- flake8-bugbear's new B028 error requires ``f"'{foo}'"`` to be replaced with ``f"{foo!r}"``
- flake8-bugbear's new B905 error requires the ``stric``' argument when using Python's ``zip`` function. However, this parameter has been introduced in Python 3.10. That is, if using Python <3.10, this check should be deactivated.

https://github.com/PyCQA/flake8-bugbear